### PR TITLE
Use puppetlabs/netdev_stdlib instead of netdevops/netdev_stdlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 # CHANGELOG
 v0.0.1 (10.2013) - Added netdev_stdlib Mellanox providers
 v1.0.0 (01.2014) - Added module types and Mellanox providers + OSPF Mellanox providers
+v1.0.1 (12.2015) - Use puppetlabs/netdev_stdlib instead of netdevops/netdev_stdlib

--- a/Modulefile
+++ b/Modulefile
@@ -1,6 +1,6 @@
 name 'mellanox-netdev_stdlib_mlnxos'
 
-version '1.0.0'
+version '1.0.1'
 
 source 'https://github.com/Mellanox/mellanox-netdev-stdlib-mlnxos'
 
@@ -14,5 +14,5 @@ description 'Mellanox providers code for Netdev types, which provides a vendor-n
 
 project_page 'https://github.com/Mellanox/mellanox-netdev-stdlib-mlnxos'
 
-dependency 'netdevops/netdev_stdlib', '>= 1.0.0'
+dependency 'puppetlabs/netdev_stdlib', '>= 0.11.0'
 dependency 'mellanox/netdev_ospf_stdlib', '>= 1.0.0'

--- a/README
+++ b/README
@@ -3,7 +3,7 @@
 Netdev is a vendor-neutral network abstraction framework contributed freely to the DevOps community.
 
 This module contains the mlnx-os specific Provider code implementing the Resource Types defined in
-[netdevops/netdev_stdlib](https://github.com/NetdevOps/puppet-netdev-stdlib).
+[puppetlabs/netdev_stdlib](https://github.com/puppetlabs/netdev_stdlib).
 
 # EXAMPLE USAGE
 
@@ -63,14 +63,14 @@ node "My_Ethernet_switch" {
 
 # DEPENDENCIES
 
-  * Puppet module netdevops/netdev_stdlib version >= 1.0.0
+  * Puppet module puppetlabs/netdev_stdlib version >= 0.11.0
   * MLNX-OS with puppet support:
     * switchx-1036,  switchx-6036, switchx-1016:
       - 4300
 
 # INSTALLATION ON PUPPET-MASTER
 
-  * puppet module install netdevops-netdev_stdlib
+  * puppet module install puppetlabs-netdev_stdlib
   * puppet module install mellanox-netdev_ospf_stdlib
   * puppet module install mellanox-netdev_stdlib_mlnxos
 

--- a/metadata.json
+++ b/metadata.json
@@ -3,12 +3,12 @@
   "checksums": {
     "lib/puppet/provider/netdev_l3_interface/mlnxos.rb": "3922d7dadbd1a096e5985f0ab572d11a",
     "LICENSE": "c4f312808b2c126959c93563ab45bd83",
-    "CHANGELOG.md": "d58a0e5fbdad0460c54454c309cbcd4f",
+    "CHANGELOG.md": "a56881276beea9a4e4d72027db2e2f7b",
     "lib/puppet/provider/netdev_vlan/mlnxos.rb": "4c6bf0a4f758f222bca8905e72258f48",
     "lib/puppet/provider/netdev_device/mlnxos.rb": "8b3b8cd05a51ce57d7113fd653ed296a",
     "lib/puppet/type/mlnx_fetched_img.rb": "40730d223777d1545b245a1324a1a696",
     "lib/puppet/provider/netdev_router_ospf/mlnxos.rb": "89ccbc7d7e789a3b063e0bd79aff53cb",
-    "README": "fde04b53a91ba339ed65b5028156987e",
+    "README": "148e9adfdbfc7a17c6a23369ee91173d",
     "lib/puppet/provider/netdev_l2_interface/mlnxos.rb": "181a29202ebe87de9d0f55d907d375d6",
     "lib/puppet/provider/mlnx_installed_img/mlnxos.rb": "df2a8247742a0c642dd00700e500a0a5",
     "lib/puppet/provider/netdev_lag/mlnxos.rb": "51f37236e3a7ea5fb7cffa4a47c63541",
@@ -18,7 +18,7 @@
     "lib/puppet/type/netdev_l3_interface.rb": "e46b5c5404d04be09de29146c503abe6",
     "lib/puppet/provider/netdev_interface/mlnxos.rb": "d9e1362a7ad0b4c29585c87a969229ae",
     "lib/puppet/type/mlnx_protocol.rb": "d46b17718f18a3f580d6c0c5fab26c81",
-    "Modulefile": "5fc03ece05ace4d3372ca53586a690cb",
+    "Modulefile": "638384095868fd58f641d5be4193d1e5",
     "lib/puppet/type/mlnx_installed_img.rb": "1c0928783585464bdd59e39afc3e586c",
     "lib/puppet/provider/mlnx_fetched_img/mlnxos.rb": "9a57034ff7ee3ca7e87d89a0e72ebc84",
     "lib/facter/mlnxos_version.rb": "8bdf68682bffe74d7ee75e96f8343e43"
@@ -28,8 +28,8 @@
   "description": "Mellanox providers code for Netdev types, which provides a vendor-neutral network abstraction framework for managing network devices",
   "dependencies": [
     {
-      "version_requirement": ">= 1.0.0",
-      "name": "netdevops/netdev_stdlib"
+      "version_requirement": ">= 0.11.0",
+      "name": "puppetlabs/netdev_stdlib"
     },
     {
       "version_requirement": ">= 1.0.0",
@@ -181,5 +181,5 @@
       "doc": "Manages an image installation on a network device."
     }
   ],
-  "version": "1.0.0"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
`netdevops/netdev_stdlib` is renamed to `puppetlabs/netdev_stdlib`. Also its GitHub repository,  https://github.com/NetdevOps/puppet-netdev-stdlib is moved to https://github.com/puppetlabs/netdev_stdlib.
